### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ This repository contains a simple static website for the "Information in Motion"
 
 To view the website locally, open `InfoM.website.html` or `index.html` in your web browser. No additional setup is required.
 
+## Live Site
+
+This repository includes a GitHub Actions workflow that deploys the site to GitHub Pages.
+After pushing to `main` and enabling Pages in repository settings, the site will be accessible at `https://your-username.github.io/InformationinMotion/`.
+
 ## Development Instructions
 
 1. Clone this repository.


### PR DESCRIPTION
## Summary
- configure GitHub Actions workflow to deploy the site to GitHub Pages
- document live site details and deployment steps in README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68928a65aff8832ebe59defdaa5c95bb